### PR TITLE
Fix(Calendar): 修复 #13 中提到的几个问题

### DIFF
--- a/packages/taro-ui-vue-demo/src/pages/advanced/calendar/index.vue
+++ b/packages/taro-ui-vue-demo/src/pages/advanced/calendar/index.vue
@@ -1,117 +1,111 @@
 <template>
-  <view class='page calendar-page'>
-    <DocsHeader title='Calendar 日历' />
+  <view class="page calendar-page">
+    <DocsHeader title="Calendar 日历" />
 
-    <view class='doc-body'>
-      <view class='panel'>
-        <view class='panel__title'>一般案例</view>
-        <view class='panel__content'>
+    <view class="doc-body">
+      <view class="panel">
+        <view class="panel__title">一般案例</view>
+        <view class="panel__content">
           <AtCalendar :onMonthChange="handleMonthChange" />
         </view>
       </view>
 
-      <view class='panel'>
-        <view class='panel__title'>跳转到指定日期</view>
-        <view class='panel__content'>
+      <view class="panel">
+        <view class="panel__title">跳转到指定日期</view>
+        <view class="panel__content">
           <AtCalendar :currentDate="state.now" />
-          <view class='body_controllers'>
+          <view class="body_controllers">
             <AtButton
-              size='small'
+              size="small"
               :onClick="handleClick.bind(this, 'now', '2018/01/01')"
-            >
-              跳转到 2018/01/01
-            </AtButton>
+            >跳转到 2018/01/01</AtButton>
             <AtButton
-              size='small'
+              size="small"
               :onClick="handleClick.bind(this, 'now', '2018/06/18')"
-            >
-              跳转到 2018/6/18
-            </AtButton>
+            >跳转到 2018/6/18</AtButton>
           </view>
         </view>
       </view>
 
-      <view class='panel'>
-        <view class='panel__title'>指定最小日期和最大日期</view>
-        <view class='panel__content'>
-          <AtCalendar :minDate="state.minDate" :maxDate="state.maxDate" />
-          <view class='body_controllers'>
+      <view class="panel">
+        <view class="panel__title">指定最小日期和最大日期</view>
+        <view class="panel__content">
+          <AtCalendar
+            :minDate="state.minDate"
+            :maxDate="state.maxDate"
+          />
+          <view class="body_controllers">
             <AtButton
-              size='small'
+              size="small"
               :onClick="handleClick.bind(this, 'minDate', '2018/01/01')"
-            >
-              设置最小值 2018/1/1
-            </AtButton>
+            >设置最小值 2018/1/1</AtButton>
             <AtButton
-              size='small'
+              size="small"
               :onClick="handleClick.bind(this, 'maxDate', '2019/12/31')"
-            >
-              设置最大值 2019/12/31
-            </AtButton>
+            >设置最大值 2019/12/31</AtButton>
           </view>
         </view>
       </view>
 
-      <view class='panel'>
-        <view class='panel__title'>标记时间</view>
-        <view class='panel__content'>
+      <view class="panel">
+        <view class="panel__title">标记时间</view>
+        <view class="panel__content">
           <AtCalendar :marks="state.mark" />
-          <view class='body_controllers'>
+          <view class="body_controllers">
             <AtButton
-              size='small'
-              class='button'
+              size="small"
+              class="button"
               :onClick="handleClick.bind(this, 'mark', [
                 {
                   value: Date.now()
                 }
               ])"
-            >
-              标记当前时间
-            </AtButton>
+            >标记当前时间</AtButton>
           </view>
         </view>
       </view>
 
-      <view class='panel'>
-        <view class='panel__title'>禁止滑动</view>
-        <view class='panel__content'>
+      <view class="panel">
+        <view class="panel__title">禁止滑动</view>
+        <view class="panel__content">
           <AtCalendar :isSwiper="false" />
         </view>
       </view>
 
-      <view class='panel'>
-        <view class='panel__title'>垂直滑动</view>
-        <view class='panel__content'>
-          <AtCalendar isVertical :onSelectDate="handleDateChange" />
+      <view class="panel">
+        <view class="panel__title">垂直滑动</view>
+        <view class="panel__content">
+          <AtCalendar
+            isVertical
+            :onSelectDate="handleDateChange"
+          />
         </view>
       </view>
 
-      <view class='panel'>
-        <view class='panel__title'>范围选择</view>
-        <view class='panel__content'>
-          <!-- <AtCalendar
+      <view class="panel">
+        <view class="panel__title">范围选择</view>
+        <view class="panel__content">
+          <AtCalendar
             :onSelectDate="handleDateChange"
             isMultiSelect
             :currentDate="state.multiCurentDate"
-          /> -->
-          <view class='body_controllers'>
+          />
+          <view class="body_controllers">
             <AtButton
-              size='small'
-              class='button'
+              size="small"
+              class="button"
               :onClick="handleClick.bind(this, 'multiCurentDate', {
                 start: '2018/10/28',
                 end: '2018/11/11'
               })"
-            >
-              设置选择区间为 2018/10/28 - 2018/11/11
-            </AtButton>
+            >设置选择区间为 2018/10/28 - 2018/11/11</AtButton>
           </view>
         </view>
       </view>
 
-      <view class='panel'>
-        <view class='panel__title'>有效时间组</view>
-        <view class='panel__content'>
+      <view class="panel">
+        <view class="panel__title">有效时间组</view>
+        <view class="panel__content">
           <AtCalendar :validDates="state.validDates" />
         </view>
       </view>

--- a/packages/taro-ui-vue-demo/src/pages/advanced/calendar/main.ts
+++ b/packages/taro-ui-vue-demo/src/pages/advanced/calendar/main.ts
@@ -62,6 +62,10 @@ export default Vue.extend({
       })
     },
     handleDateChange(arg: any): void {
+      if(arg.value.end) {
+        this.state.multiCurentDate = arg.value
+      }
+      
       Taro.showToast({
         title: `handleDateChange: ${JSON.stringify(arg)}`,
         icon: 'none'

--- a/packages/taro-ui-vue/src/components/calendar/index.ts
+++ b/packages/taro-ui-vue/src/components/calendar/index.ts
@@ -43,7 +43,7 @@ export default {
       default: 'YYYY-MM-DD',
     },
     currentDate: {
-      type: [Number, String],
+      type: [Number, String, Date, Object],
       default: Date.now(),
     },
     monthFormat: {

--- a/packages/taro-ui-vue/src/components/calendar/index.ts
+++ b/packages/taro-ui-vue/src/components/calendar/index.ts
@@ -104,7 +104,7 @@ export default {
       if (!currentDate || currentDate === oldVal.currentDate) return
       if (isMultiSelect && oldVal.isMultiSelect) {
         const { start, end } = currentDate
-        const { start: preStart, end: preEnd } = this.currentDate
+        const { start: preStart, end: preEnd } = oldVal.currentDate
 
         if (start === preStart && preEnd === end) {
           return
@@ -272,7 +272,7 @@ export default {
       } else {
         stateValue = this.getSingleSelectdState(dayjsDate)
       }
-      this.state = stateValue
+      Object.assign(this.state, stateValue)
       this.$nextTick(() => {
         this.handleSelectedDate()
       })


### PR DESCRIPTION
本 PR 旨在修复与 #13 相关的几个额外问题：
1. 在非当前月份选择日期时，月份会跳到当前日期所在的月份
2. 更改 `currentDate` 的类型，避免在进行日期范围选择时，报类型验证错误
3. 修复日期范围选择示例。

本 PR 未能解决的问题：
1. 滑动切换月份时，只能在上一个月、本月、下一个月之间滑动， 不能连续滑动
2. 选择日期范围时，第一次点击选中日期的样式不是圆形，与 `Taro UI` 官方展示示例不一致。

另外，建议添加一个 prettier 的配置文件，统一一下格式。