### PR TITLE
[fix#106] 修复searchBar 的 onClear 事件无法触发的bug

### DIFF
--- a/packages/taro-ui-vue/src/components/search-bar/index.ts
+++ b/packages/taro-ui-vue/src/components/search-bar/index.ts
@@ -89,6 +89,10 @@ const AtSearchBar = {
         return function () {}
       },
     },
+    onClear: {
+      type: Function,
+      default: undefined,
+    },
   },
   computed: {
     rootCls() {
@@ -167,7 +171,7 @@ const AtSearchBar = {
       this.onChange(e.target.value, e)
     },
     handleClear(event: CommonEvent): void {
-      if (this.onClear) {
+      if (this.onClear && this.onClear instanceof Function) {
         this.onClear(event)
       } else {
         this.onChange('', event)


### PR DESCRIPTION
fix#106: fix SearchBar onClear event handler not working properly