### PR TITLE
docs(tabbar): modify the wrong function name

### DIFF
--- a/packages/taro-ui-vue-docs/markdown/tabbar.md
+++ b/packages/taro-ui-vue-docs/markdown/tabbar.md
@@ -64,7 +64,7 @@ export default {
     }
   },
   methods: {
-    onClick(value) {
+    handleClick(value) {
       this.current1 = value
     }
   },


### PR DESCRIPTION
修改文档中tabbar部分，一个和上文不匹配的函数名。

![](http://qny.volcanoblog.cn/markdown/20210314105841.png)